### PR TITLE
Gather controlplane build scripts into the examples repo

### DIFF
--- a/controlplane/build-controller.sh
+++ b/controlplane/build-controller.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -x
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+MAKEDIR=$SCRIPTDIR/../../controller/
+
+make -C $MAKEDIR build
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo -e "\n***********\nFAILED: make failed for controller.\n***********\n"
+    exit $STATUS
+fi
+
+make -C $MAKEDIR docker IMAGE_NAME=controller-0.1
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo -e "\n***********\nFAILED: docker build failed for controller.\n***********\n"
+    exit $STATUS
+fi

--- a/controlplane/build-registry.sh
+++ b/controlplane/build-registry.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -x
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+MAKEDIR=$SCRIPTDIR/../../registry/
+
+make -C $MAKEDIR build
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo -e "\n***********\nFAILED: make failed for registry.\n***********\n"
+    exit $STATUS
+fi
+
+make -C $MAKEDIR docker IMAGE_NAME=registry-0.1
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo -e "\n***********\nFAILED: docker build failed for registry.\n***********\n"
+    exit $STATUS
+fi

--- a/controlplane/build-sidecar.sh
+++ b/controlplane/build-sidecar.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -x
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+MAKEDIR=$SCRIPTDIR/../../sidecar/
+
+make -C $MAKEDIR build
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo -e "\n***********\nFAILED: make failed for sidecar.\n***********\n"
+    exit $STATUS
+fi
+
+make -C $MAKEDIR docker IMAGE_NAME=kube-sidecar-reg:0.1 DOCKERFILE=./docker/Dockerfile.kube.reg
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo -e "\n***********\nFAILED: docker build failed for sidecar register.\n***********\n"
+    exit $STATUS
+fi
+
+make -C $MAKEDIR docker IMAGE_NAME=kube-sidecar-proxy:0.1 DOCKERFILE=./docker/Dockerfile.kube.proxy
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo -e "\n***********\nFAILED: docker build failed for sidecar proxy.\n***********\n"
+    exit $STATUS
+fi

--- a/controlplane/run-controlplane.sh
+++ b/controlplane/run-controlplane.sh
@@ -9,17 +9,17 @@ mhfile="messagehub.yaml"
 lgfile="logserver.yaml"
 
 if [ "$1" == "compile" ]; then
-    $SCRIPTDIR/../../sidecar/build.sh
+    $SCRIPTDIR/build-sidecar.sh
     if [ $? -ne 0 ]; then
         echo "Sidecar failed to compile"
         exit 1
     fi
-    $SCRIPTDIR/../../registry/build.sh
+    $SCRIPTDIR/build-registry.sh
     if [ $? -ne 0 ]; then
         echo "Registry failed to compile"
         exit 1
     fi
-    $SCRIPTDIR/../../controller/build.sh
+    $SCRIPTDIR/build-controller.sh
     if [ $? -ne 0 ]; then
         echo "Controller failed to compile"
         exit 1


### PR DESCRIPTION
This PR gathers the various `build.sh` from the registry/controller/sidecar repo's, into the examples repo. Subsequent PRs will remove the duplicate `build.sh` from the registry/controller/sidecar repo's.