### PR TITLE
Replace Registry's JWT tokens with 'trusted' auth mode

### DIFF
--- a/apps/helloworld/README.md
+++ b/apps/helloworld/README.md
@@ -110,8 +110,7 @@ Before you begin, follow the environment set up instructions at https://github.c
 You can look at registration details for a service in the A8 registry, by running the following cURL command:
 
 ```
-export TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
-curl -X GET -H "Authorization: Bearer ${TOKEN}" http://localhost:31300/api/v1/services/helloworld | jq .
+curl -X GET -H "Authorization: Bearer local" http://localhost:31300/api/v1/services/helloworld | jq .
 ```
 
 **Note**: Replace localhost:31300 above with the appropriate host

--- a/apps/helloworld/hellosidecar.yaml
+++ b/apps/helloworld/hellosidecar.yaml
@@ -41,7 +41,7 @@ spec:
         - name: REGISTRY_URL
           value: http://$(REGISTRY_SERVICE_HOST):$(REGISTRY_SERVICE_PORT)
         - name: REGISTRY_TOKEN
-          value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+          value: local
         - name: ENDPOINT_HOST
           valueFrom:
             fieldRef:
@@ -78,7 +78,7 @@ spec:
         - name: REGISTRY_URL
           value: http://$(REGISTRY_SERVICE_HOST):$(REGISTRY_SERVICE_PORT)
         - name: REGISTRY_TOKEN
-          value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+          value: local
         - name: ENDPOINT_HOST
           valueFrom:
             fieldRef:

--- a/docker/bookinfo.yaml
+++ b/docker/bookinfo.yaml
@@ -16,7 +16,7 @@ details-v1:
   image: amalgam8/a8-examples-bookinfo-details-sidecar:v1
   environment:
     - REGISTRY_URL=http://registry:8080
-    - REGISTRY_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+    - REGISTRY_TOKEN=local
     - SERVICE=details
     - SERVICE_VERSION=v1
     - LOG=false
@@ -29,7 +29,7 @@ ratings-v1:
   image: amalgam8/a8-examples-bookinfo-ratings-sidecar:v1
   environment:
     - REGISTRY_URL=http://registry:8080
-    - REGISTRY_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+    - REGISTRY_TOKEN=local
     - SERVICE=ratings
     - SERVICE_VERSION=v1
     - LOG=false
@@ -42,7 +42,7 @@ reviews-v1:
   image: amalgam8/a8-examples-bookinfo-reviews-sidecar:v1
   environment:
     - REGISTRY_URL=http://registry:8080
-    - REGISTRY_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+    - REGISTRY_TOKEN=local
     - SERVICE=reviews
     - SERVICE_VERSION=v1
     - LOG=false
@@ -55,7 +55,7 @@ reviews-v2:
   image: amalgam8/a8-examples-bookinfo-reviews-sidecar:v2
   environment:
     - REGISTRY_URL=http://registry:8080
-    - REGISTRY_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+    - REGISTRY_TOKEN=local
     - SERVICE=reviews
     - SERVICE_VERSION=v2
     - ENDPOINT_PORT=9080
@@ -75,7 +75,7 @@ reviews-v3:
   image: amalgam8/a8-examples-bookinfo-reviews-sidecar:v3
   environment:
     - REGISTRY_URL=http://registry:8080
-    - REGISTRY_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+    - REGISTRY_TOKEN=local
     - SERVICE=reviews
     - SERVICE_VERSION=v3
     - ENDPOINT_PORT=9080
@@ -95,7 +95,7 @@ productpage-v1:
   image: amalgam8/a8-examples-bookinfo-productpage-sidecar:v1
   environment:
     - REGISTRY_URL=http://registry:8080
-    - REGISTRY_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+    - REGISTRY_TOKEN=local
     - SERVICE=productpage
     - SERVICE_VERSION=v1
     - ENDPOINT_PORT=9080

--- a/docker/controlplane.yaml
+++ b/docker/controlplane.yaml
@@ -56,7 +56,7 @@ registry:
   image: amalgam8/a8-registry:0.1
   ports:
     - "31300:8080"
-  command: -auth_mode=jwt -jwt_secret=12345
+  command: -auth_mode=trusted
   container_name: registry
 
 controller:

--- a/docker/helloworld.yaml
+++ b/docker/helloworld.yaml
@@ -16,7 +16,7 @@ helloworld-v1:
   image: amalgam8/a8-examples-helloworld-sidecar:v1
   environment:
     - REGISTRY_URL=http://registry:8080
-    - REGISTRY_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+    - REGISTRY_TOKEN=local
     - SERVICE=helloworld
     - SERVICE_VERSION=v1
     - LOG=false
@@ -29,7 +29,7 @@ helloworld-v2:
   image: amalgam8/a8-examples-helloworld-sidecar:v2
   environment:
     - REGISTRY_URL=http://registry:8080
-    - REGISTRY_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+    - REGISTRY_TOKEN=local
     - SERVICE=helloworld
     - SERVICE_VERSION=v2
     - LOG=false

--- a/docker/run-controlplane-docker.sh
+++ b/docker/run-controlplane-docker.sh
@@ -40,7 +40,7 @@ if [ "$1" == "start" ]; then
         },
         "registry": {
             "url": "http://${AR}",
-            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY"
+            "token": "local"
         }
     }
 }

--- a/kubernetes/bookinfo.yaml
+++ b/kubernetes/bookinfo.yaml
@@ -50,7 +50,7 @@ spec:
         - name: REGISTRY_URL
           value: http://$(REGISTRY_SERVICE_HOST):$(REGISTRY_SERVICE_PORT)
         - name: REGISTRY_TOKEN
-          value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+          value: local
         - name: ENDPOINT_HOST
           valueFrom:
             fieldRef:
@@ -96,7 +96,7 @@ spec:
         - name: REGISTRY_URL
           value: http://$(REGISTRY_SERVICE_HOST):$(REGISTRY_SERVICE_PORT)
         - name: REGISTRY_TOKEN
-          value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+          value: local
         - name: ENDPOINT_HOST
           valueFrom:
             fieldRef:

--- a/kubernetes/helloworld.yaml
+++ b/kubernetes/helloworld.yaml
@@ -55,7 +55,7 @@ spec:
         - name: REGISTRY_URL
           value: http://$(REGISTRY_SERVICE_HOST):$(REGISTRY_SERVICE_PORT)
         - name: REGISTRY_TOKEN
-          value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+          value: local
         - name: ENDPOINT_HOST
           valueFrom:
             fieldRef:
@@ -106,7 +106,7 @@ spec:
         - name: REGISTRY_URL
           value: http://$(REGISTRY_SERVICE_HOST):$(REGISTRY_SERVICE_PORT)
         - name: REGISTRY_TOKEN
-          value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY
+          value: local
         - name: ENDPOINT_HOST
           valueFrom:
             fieldRef:

--- a/kubernetes/post-tenant.sh
+++ b/kubernetes/post-tenant.sh
@@ -32,7 +32,7 @@ read -d '' tenant << EOF
         },
         "registry": {
             "url": "http://${AR}",
-            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY"
+            "token": "local"
         }
     }
 }

--- a/kubernetes/registry.yaml
+++ b/kubernetes/registry.yaml
@@ -50,6 +50,6 @@ spec:
       - name: registry
         image: amalgam8/a8-registry:0.1
         imagePullPolicy: IfNotPresent
-        args: ["-auth_mode=jwt", "-jwt_secret=12345"]
+        args: ["-auth_mode=trusted"]
         ports:
         - containerPort: 8080

--- a/kubernetes/run-controlplane-gcp.sh
+++ b/kubernetes/run-controlplane-gcp.sh
@@ -51,7 +51,7 @@ if [ "$1" == "start" ]; then
         },
         "registry": {
             "url": "http://${AR}",
-            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY"
+            "token": "local"
         }
     }
 }

--- a/kubernetes/run-controlplane-local-k8s.sh
+++ b/kubernetes/run-controlplane-local-k8s.sh
@@ -53,7 +53,7 @@ if [ "$1" == "start" ]; then
         },
         "registry": {
             "url": "http://${AR}",
-            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY"
+            "token": "local"
         }
     }
 }

--- a/marathon/bookinfo.json
+++ b/marathon/bookinfo.json
@@ -23,7 +23,7 @@
                     "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --log=false --proxy=false --supervise python details.py 9080 http://localhost:6379",
 		            "env": {
                         "REGISTRY_URL": "http://__REPLACEME__:31300",
-			            "REGISTRY_TOKEN" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY",
+			            "REGISTRY_TOKEN" : "local",
 			            "SERVICE" : "details",
                         "SERVICE_VERSION" : "v1"
 		            },
@@ -50,7 +50,7 @@
                     "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --log=false --proxy=false --supervise python ratings.py 9080 http://localhost:6379",
 		            "env": {
                         "REGISTRY_URL": "http://__REPLACEME__:31300",
-			            "REGISTRY_TOKEN" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY",
+			            "REGISTRY_TOKEN" : "local",
 			            "SERVICE" : "ratings",
                         "SERVICE_VERSION" : "v1"
 		            },
@@ -77,7 +77,7 @@
                     "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --log=false --proxy=false --supervise python reviews.py 9080 http://localhost:6379",
 		            "env": {
                         "REGISTRY_URL": "http://__REPLACEME__:31300",
-			            "REGISTRY_TOKEN" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY",
+			            "REGISTRY_TOKEN" : "local",
 			            "SERVICE" : "reviews",
                         "SERVICE_VERSION" : "v1"
 		            },
@@ -104,7 +104,7 @@
                     "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --supervise python reviews.py 9080 http://localhost:6379",
 		            "env": {
                         "REGISTRY_URL": "http://__REPLACEME__:31300",
-			            "REGISTRY_TOKEN" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY",
+			            "REGISTRY_TOKEN" : "local",
 			            "SERVICE" : "reviews",
                         "SERVICE_VERSION" : "v2",
 			            "TENANT_TOKEN":"12345",
@@ -137,7 +137,7 @@
                     "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --supervise python reviews.py 9080 http://localhost:6379",
 		            "env": {
                         "REGISTRY_URL": "http://__REPLACEME__:31300",
-			            "REGISTRY_TOKEN" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY",
+			            "REGISTRY_TOKEN" : "local",
 			            "SERVICE" : "reviews",
                         "SERVICE_VERSION" : "v3",
 			            "TENANT_TOKEN":"12345",
@@ -170,7 +170,7 @@
                     "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --supervise python productpage.py 9080 http://localhost:6379",
 		            "env": {
 			            "REGISTRY_URL": "http://__REPLACEME__:31300",
-			            "REGISTRY_TOKEN" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY",
+			            "REGISTRY_TOKEN" : "local",
 			            "SERVICE" : "productpage",
 				        "SERVICE_VERSION" : "v1",
 			            "TENANT_TOKEN":"12345",

--- a/marathon/helloworld.json
+++ b/marathon/helloworld.json
@@ -23,7 +23,7 @@
 		    "cmd" : "a8sidecar --proxy=false --log=false --endpoint_host=${HOST} --endpoint_port=${PORT_5000} --supervise python -u app.py",
 		    "env": {
                 "REGISTRY_URL": "http://__REPLACEME__:31300",
-			    "REGISTRY_TOKEN" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY",
+			    "REGISTRY_TOKEN" : "local",
 			    "SERVICE" : "helloworld",
                 "SERVICE_VERSION" : "v1"
 		    },
@@ -50,7 +50,7 @@
 		    "cmd" : "a8sidecar --proxy=false --log=false --endpoint_host=${HOST} --endpoint_port=${PORT_5000} --supervise python -u app.py",
 		    "env": {
                 "REGISTRY_URL": "http://__REPLACEME__:31300",
-			    "REGISTRY_TOKEN" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY",
+			    "REGISTRY_TOKEN" : "local",
 			    "SERVICE" : "helloworld",
                 "SERVICE_VERSION" : "v2"
 		    },

--- a/marathon/registry.json
+++ b/marathon/registry.json
@@ -15,8 +15,7 @@
 	}
     },
     "args" : [
-	"-auth_mode", "jwt",
-	"-jwt_secret", "12345"
+	"-auth_mode", "trusted"
     ],
     "instances": 1,
     "cpus": 0.1,

--- a/marathon/run-controlplane-marathon.sh
+++ b/marathon/run-controlplane-marathon.sh
@@ -50,7 +50,7 @@ if [ "$1" == "start" ]; then
         },
         "registry": {
             "url": "http://${AR}",
-            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjY3NzU5NjMsIm5hbWVzcGFjZSI6Imdsb2JhbC5nbG9iYWwifQ.Gbz4G_O0OfJZiTuX6Ce4heU83gSWQLr5yyiA7eZNqdY"
+            "token": "local"
         }
     }
 }


### PR DESCRIPTION
- Launch registry with `--auth_mode=trusted` instead of `--auth_mode=jwt --jwt_secret=12345`
- Launch apps with `local` registry token instead of `eyJhbGciO...eZNqdY`
- Post controller tenant with `local` registry token instead of `eyJhbGciO...eZNqdY`
- Applies to the following demo environments: Docker-local, K8s (local/GCP), Mesos-Marathon
- Doesn't apply to Bluemix, where the registry token is fetched from VCAP_SERVICES for Service Discovery.