### PR TITLE
Remove req_tracking_header from control plane launch scripts

### DIFF
--- a/bluemix/deploy-controlplane.sh
+++ b/bluemix/deploy-controlplane.sh
@@ -122,7 +122,6 @@ echo "Setting up a new controller tenant named 'local'"
 read -d '' tenant << EOF
 {
     "id": "${CONTROLLER_TENANT_ID}",
-    "req_tracking_header" : "X-Request-ID",
     "credentials": {
         "registry": {
             "url": "${REGISTRY_URL}",

--- a/docker/run-controlplane-docker.sh
+++ b/docker/run-controlplane-docker.sh
@@ -30,7 +30,6 @@ if [ "$1" == "start" ]; then
     echo "Setting up a new tenant named 'local'"
     read -d '' tenant << EOF
 {
-    "req_tracking_header" : "X-Request-ID",
     "credentials": {
         "kafka": {
             "brokers": ["${KA}"],

--- a/kubernetes/adapter/run-controlplane-local-k8s.sh
+++ b/kubernetes/adapter/run-controlplane-local-k8s.sh
@@ -45,7 +45,6 @@ if [ "$1" == "start" ]; then
     echo "Setting up a new tenant named 'local'"
     read -d '' tenant << EOF
 {
-    "req_tracking_header" : "X-Request-ID",
     "credentials": {
         "kafka": {
             "brokers": ["${KA}"],

--- a/kubernetes/post-tenant.sh
+++ b/kubernetes/post-tenant.sh
@@ -22,7 +22,6 @@ KA=$(kubectl get svc/kafka --template={{.spec.clusterIP}}:{{\("index .spec.ports
 echo "Setting up a new tenant named 'local'"
 read -d '' tenant << EOF
 {
-    "req_tracking_header" : "X-Request-ID",
     "credentials": {
         "kafka": {
             "brokers": ["${KA}"],

--- a/kubernetes/run-controlplane-gcp.sh
+++ b/kubernetes/run-controlplane-gcp.sh
@@ -41,7 +41,6 @@ if [ "$1" == "start" ]; then
     echo "Setting up a new tenant named 'local'"
     read -d '' tenant << EOF
 {
-    "req_tracking_header" : "X-Request-ID",
     "credentials": {
         "kafka": {
             "brokers": ["${KA}"],

--- a/kubernetes/run-controlplane-local-k8s.sh
+++ b/kubernetes/run-controlplane-local-k8s.sh
@@ -43,7 +43,6 @@ if [ "$1" == "start" ]; then
     echo "Setting up a new tenant named 'local'"
     read -d '' tenant << EOF
 {
-    "req_tracking_header" : "X-Request-ID",
     "credentials": {
         "kafka": {
             "brokers": ["${KA}"],

--- a/marathon/run-controlplane-marathon.sh
+++ b/marathon/run-controlplane-marathon.sh
@@ -40,7 +40,6 @@ if [ "$1" == "start" ]; then
     echo "Setting up a new tenant named 'local'"
     read -d '' tenant << EOF
 {
-    "req_tracking_header" : "X-Request-ID",
     "credentials": {
         "kafka": {
             "brokers": ["${KA}"],


### PR DESCRIPTION
This field is now obsolete. 