### PR TITLE
Prefix Registry env vars with A8_

### DIFF
--- a/bluemix/deploy-controlplane.sh
+++ b/bluemix/deploy-controlplane.sh
@@ -68,7 +68,7 @@ else
             --min 1 --max 2 --desired 1 \
             --hostname $REGISTRY_HOSTNAME \
             --domain $ROUTES_DOMAIN \
-            --env AUTH_MODE=trusted \
+            --env A8_AUTH_MODE=trusted \
             ${BLUEMIX_REGISTRY_HOST}/${BLUEMIX_REGISTRY_NAMESPACE}/${REGISTRY_IMAGE}
 fi
 


### PR DESCRIPTION
This affects only the Bluemix example, as it's the only one that still sets environment variables for the Registry (to enable trusted auth).

Note: The `A8_` prefix is being added to the Registry env vars as part of amalgam8/registry#40, and is targeted for inclusion in v0.3.