### PR TITLE
Change environment setups for new sidecar defaults

### DIFF
--- a/docker/bookinfo.yaml
+++ b/docker/bookinfo.yaml
@@ -17,8 +17,7 @@ details-v1:
   environment:
     - A8_REGISTRY_URL=http://registry:8080
     - A8_SERVICE=details:v1
-    - A8_LOG=false
-    - A8_PROXY=false
+    - A8_REGISTER=true
     - A8_ENDPOINT_PORT=9080
   external_links:
     - registry
@@ -28,8 +27,7 @@ ratings-v1:
   environment:
     - A8_REGISTRY_URL=http://registry:8080
     - A8_SERVICE=ratings:v1
-    - A8_LOG=false
-    - A8_PROXY=false
+    - A8_REGISTER=true
     - A8_ENDPOINT_PORT=9080
   external_links:
     - registry
@@ -39,8 +37,7 @@ reviews-v1:
   environment:
     - A8_REGISTRY_URL=http://registry:8080
     - A8_SERVICE=reviews:v1
-    - A8_LOG=false
-    - A8_PROXY=false
+    - A8_REGISTER=true
     - A8_ENDPOINT_PORT=9080
   external_links:
     - registry
@@ -48,6 +45,9 @@ reviews-v1:
 reviews-v2:
   image: amalgam8/a8-examples-bookinfo-reviews-sidecar:v2-alpine
   environment:
+    - A8_LOG=true
+    - A8_REGISTER=true
+    - A8_PROXY=true
     - A8_REGISTRY_URL=http://registry:8080
     - A8_SERVICE=reviews:v2
     - A8_ENDPOINT_PORT=9080
@@ -63,6 +63,9 @@ reviews-v2:
 reviews-v3:
   image: amalgam8/a8-examples-bookinfo-reviews-sidecar:v3-alpine
   environment:
+    - A8_LOG=true
+    - A8_REGISTER=true
+    - A8_PROXY=true
     - A8_REGISTRY_URL=http://registry:8080
     - A8_SERVICE=reviews:v3
     - A8_ENDPOINT_PORT=9080
@@ -78,6 +81,9 @@ reviews-v3:
 productpage-v1:
   image: amalgam8/a8-examples-bookinfo-productpage-sidecar:v1-alpine
   environment:
+    - A8_LOG=true
+    - A8_REGISTER=true
+    - A8_PROXY=true
     - A8_REGISTRY_URL=http://registry:8080
     - A8_SERVICE=productpage:v1
     - A8_ENDPOINT_PORT=9080

--- a/docker/gateway.yaml
+++ b/docker/gateway.yaml
@@ -18,11 +18,13 @@ gateway:
   environment:
     - A8_CONTROLLER_URL=http://controller:6379
     - A8_REGISTRY_URL=http://registry:8080
-    - A8_REGISTER=false
+    - A8_PROXY=true
+    - A8_LOG=true
     - A8_SERVICE=gateway
     - A8_LOGSTASH_SERVER='logstash:8092'
     - A8_CONTROLLER_POLL=5s
     - A8_REGISTRY_POLL=5s
+    - A8_LOG_LEVEL=debug
   ports:
     - "32000:6379"
   external_links:

--- a/docker/helloworld.yaml
+++ b/docker/helloworld.yaml
@@ -17,8 +17,7 @@ helloworld-v1:
   environment:
     - A8_REGISTRY_URL=http://registry:8080
     - A8_SERVICE=helloworld:v1
-    - A8_LOG=false
-    - A8_PROXY=false
+    - A8_REGISTER=true
     - A8_ENDPOINT_PORT=5000
   external_links:
     - registry
@@ -28,8 +27,7 @@ helloworld-v2:
   environment:
     - A8_REGISTRY_URL=http://registry:8080
     - A8_SERVICE=helloworld:v2
-    - A8_LOG=false
-    - A8_PROXY=false
+    - A8_REGISTER=true
     - A8_ENDPOINT_PORT=5000
   external_links:
     - registry

--- a/kubernetes/bookinfo.yaml
+++ b/kubernetes/bookinfo.yaml
@@ -36,11 +36,9 @@ spec:
       - name: servicereg
         image: amalgam8/a8-sidecar:alpine
         imagePullPolicy: IfNotPresent
-        args:
-          - --proxy=false
-          - --log=false
-          - --supervise=false
         env:
+        - name: A8_REGISTER
+          value: "true"
         - name: A8_SERVICE
           value: details:v1
         - name: A8_LOGSTASH_SERVER
@@ -78,11 +76,9 @@ spec:
       - name: servicereg
         image: amalgam8/a8-sidecar:alpine
         imagePullPolicy: IfNotPresent
-        args:
-          - --proxy=false
-          - --log=false
-          - --supervise=false
         env:
+        - name: A8_REGISTER
+          value: "true"
         - name: A8_SERVICE
           value: ratings:v1
         - name: A8_LOGSTASH_SERVER
@@ -123,6 +119,12 @@ spec:
         ports:
         - containerPort: 6379
         env:
+        - name: A8_REGISTER
+          value: "true"
+        - name: A8_PROXY
+          value: "true"
+        - name: A8_LOG
+          value: "true"
         - name: A8_CONTROLLER_URL
           value: http://$(CONTROLLER_SERVICE_HOST):$(CONTROLLER_SERVICE_PORT)
         - name: A8_CONTROLLER_POLL
@@ -169,6 +171,12 @@ spec:
         ports:
         - containerPort: 6379
         env:
+        - name: A8_REGISTER
+          value: "true"
+        - name: A8_PROXY
+          value: "true"
+        - name: A8_LOG
+          value: "true"
         - name: A8_CONTROLLER_URL
           value: http://$(CONTROLLER_SERVICE_HOST):$(CONTROLLER_SERVICE_PORT)
         - name: A8_CONTROLLER_POLL
@@ -215,6 +223,12 @@ spec:
         ports:
         - containerPort: 6379
         env:
+        - name: A8_REGISTER
+          value: "true"
+        - name: A8_PROXY
+          value: "true"
+        - name: A8_LOG
+          value: "true"
         - name: A8_CONTROLLER_URL
           value: http://$(CONTROLLER_SERVICE_HOST):$(CONTROLLER_SERVICE_PORT)
         - name: A8_CONTROLLER_POLL
@@ -261,6 +275,12 @@ spec:
         ports:
         - containerPort: 6379
         env:
+        - name: A8_REGISTER
+          value: "true"
+        - name: A8_PROXY
+          value: "true"
+        - name: A8_LOG
+          value: "true"
         - name: A8_CONTROLLER_URL
           value: http://$(CONTROLLER_SERVICE_HOST):$(CONTROLLER_SERVICE_PORT)
         - name: A8_CONTROLLER_POLL

--- a/kubernetes/gateway.yaml
+++ b/kubernetes/gateway.yaml
@@ -50,6 +50,10 @@ spec:
         ports:
         - containerPort: 6379
         env:
+        - name: A8_PROXY
+          value: "true"
+        - name: A8_LOG
+          value: "true"
         - name: A8_CONTROLLER_URL
           value: http://$(CONTROLLER_SERVICE_HOST):$(CONTROLLER_SERVICE_PORT)
         - name: A8_REGISTRY_URL
@@ -63,5 +67,3 @@ spec:
           value: 5s
         - name: A8_REGISTRY_POLL
           value: 5s
-        - name: A8_REGISTER
-          value: "false"

--- a/kubernetes/helloworld.yaml
+++ b/kubernetes/helloworld.yaml
@@ -39,11 +39,9 @@ spec:
       - name: servicereg
         image: amalgam8/a8-sidecar:alpine
         imagePullPolicy: IfNotPresent
-        args:
-          - --proxy=false
-          - --log=false
-          - --supervise=false
         env:
+        - name: A8_REGISTER
+          value: "true"
         - name: A8_SERVICE
           value: helloworld:v1
         - name: A8_LOGSTASH_SERVER
@@ -84,11 +82,9 @@ spec:
       - name: servicereg
         image: amalgam8/a8-sidecar:alpine
         imagePullPolicy: IfNotPresent
-        args:
-          - --proxy=false
-          - --log=false
-          - --supervise=false
         env:
+        - name: A8_REGISTER
+          value: "true"
         - name: A8_SERVICE
           value: helloworld:v2
         - name: A8_LOGSTASH_SERVER

--- a/marathon/bookinfo.json
+++ b/marathon/bookinfo.json
@@ -20,9 +20,9 @@
 			                ]
 			            }
 		            },
-                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --log=false --proxy=false --supervise python details.py 9080 http://localhost:6379",
+                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --register --supervise python details.py 9080 http://localhost:6379",
 		            "env": {
-                        "A8_REGISTRY_URL": "http://__REPLACEME__:31300",
+                        "A8_REGISTRY_URL" : "http://__REPLACEME__:31300",
 			            "A8_SERVICE" : "details:v1"
 		            },
 		            "instances": 1,
@@ -45,7 +45,7 @@
 			                ]
 			            }
 		            },
-                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --log=false --proxy=false --supervise python ratings.py 9080 http://localhost:6379",
+                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --register --supervise python ratings.py 9080 http://localhost:6379",
 		            "env": {
                         "A8_REGISTRY_URL": "http://__REPLACEME__:31300",
 			            "A8_SERVICE" : "ratings:v1"
@@ -70,7 +70,7 @@
 			                ]
 			            }
 		            },
-                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --log=false --proxy=false --supervise python reviews.py 9080 http://localhost:6379",
+                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --register --supervise python reviews.py 9080 http://localhost:6379",
 		            "env": {
                         "A8_REGISTRY_URL": "http://__REPLACEME__:31300",
 			            "A8_SERVICE" : "reviews:v1"
@@ -95,7 +95,7 @@
 			                ]
 			            }
 		            },
-                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --supervise python reviews.py 9080 http://localhost:6379",
+                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --register --proxy --log --supervise python reviews.py 9080 http://localhost:6379",
 		            "env": {
                         "A8_REGISTRY_URL": "http://__REPLACEME__:31300",
 						"A8_REGISTRY_POLL" : "5s",
@@ -124,7 +124,7 @@
 			                ]
 			            }
 		            },
-                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --supervise python reviews.py 9080 http://localhost:6379",
+                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --register --proxy --log --supervise python reviews.py 9080 http://localhost:6379",
 		            "env": {
                         "A8_REGISTRY_URL": "http://__REPLACEME__:31300",
 						"A8_REGISTRY_POLL" : "5s",
@@ -153,7 +153,7 @@
 			                ]
 			            }
 		            },
-                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080} --supervise python productpage.py 9080 http://localhost:6379",
+                    "cmd" : "a8sidecar --endpoint_host=${HOST} --endpoint_port=${PORT_9080}  --register --proxy --log --supervise python productpage.py 9080 http://localhost:6379",
 		            "env": {
 			            "A8_REGISTRY_URL": "http://__REPLACEME__:31300",
 						"A8_REGISTRY_POLL" : "5s",

--- a/marathon/gateway.json
+++ b/marathon/gateway.json
@@ -14,7 +14,7 @@
 	    ]
 	}
     },
-    "cmd" : "a8sidecar --register=false --supervise=false",
+    "cmd" : "a8sidecar --proxy --log --supervise=false",
     "env": {
 		"A8_SERVICE" : "gateway",
 		"A8_REGISTRY_URL": "http://__REPLACEME__:31300",

--- a/marathon/helloworld.json
+++ b/marathon/helloworld.json
@@ -20,8 +20,9 @@
 			    ]
 			}
 		    },
-		    "cmd" : "a8sidecar --proxy=false --log=false --endpoint_host=${HOST} --endpoint_port=${PORT_5000} --supervise python -u app.py",
+		    "cmd" : "a8sidecar --register --endpoint_host=${HOST} --endpoint_port=${PORT_5000} --supervise python -u app.py",
 		    "env": {
+				"A8_REGISTER": "true",
                 "A8_REGISTRY_URL": "http://__REPLACEME__:31300",
 			    "A8_SERVICE" : "helloworld:v1"
 		    },
@@ -45,8 +46,9 @@
 			    ]
 			}
 		    },
-		    "cmd" : "a8sidecar --proxy=false --log=false --endpoint_host=${HOST} --endpoint_port=${PORT_5000} --supervise python -u app.py",
+		    "cmd" : "a8sidecar --register --endpoint_host=${HOST} --endpoint_port=${PORT_5000} --supervise python -u app.py",
 		    "env": {
+				"A8_REGISTER": "true",
                 "A8_REGISTRY_URL": "http://__REPLACEME__:31300",
 			    "A8_SERVICE" : "helloworld:v2"
 		    },


### PR DESCRIPTION
Changed example environment setups to account for different default values for --register, --proxy, and --log in sidecar.

I have verified Kubernetes and Docker, but not Marathon or Bluemix.

See https://github.com/amalgam8/sidecar/issues/45.